### PR TITLE
Update divs layout in about section (#5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,61 +67,64 @@
                     bug tracker integration, fast search, powerful access control and external API.
                 </p>
             </div>
-
-            <div class="rTable secondary">
-                <div class="rTableBody">
-                    <div class="rTableRow">
-                        <div class="rTableHead">Everyday testing</div>
-                        <div class="rTableHead">Test management</div>
-                        <div class="rTableHead">Reporting</div>
-                        <div class="rTableHead">Integration</div>
-                    </div>
-                    <div class="rTableRow">
-                        <div class="rTableCell">Use the dashboard to see pending work. Execute tests, mark results and report bugs. Collect automation results!</div>
-                        <div class="rTableCell">Define test plans and cases, track progress and assign work across multiple teams. Perform peer reviews.</div>
-                        <div class="rTableCell">See who's doing what and provide status report to stakeholders. Centralize your acceptance books!</div>
-                        <div class="rTableCell">Integrated with Bugzilla, JIRA and GitHub. The API interface provides full access so you can get creative!</div>
-                    </div>
-                    <div class="rTableRow">
-                        <div class="rTableHead">Django &amp; Python 3</div>
-                        <div class="rTableHead">Patternfly &amp; jQuery</div>
-                        <div class="rTableHead">Docker</div>
-                        <div class="rTableHead">Tested</div>
-                    </div>
-                    <div class="rTableRow">
-                        <div class="rTableCell">We're running the latest Django 1.11.x version on Python 3.5!</div>
-                        <div class="rTableCell">The UI is created using Patternfly and uses a bit of jQuery!</div>
-                        <div class="rTableCell">Based on a CentOS 7 Docker image and easy to start with docker compose.</div>
-                        <div class="rTableCell">We've got Django and Selenium based tests running in Travis CI!</div>
-                    </div>
-                    <!-- Call to action btns -->
-                    <div class="rTableRow">
-                        <div class="rTableCell">
-                            <a href="http://kiwitcms.readthedocs.io/en/latest/installing_docker.html" class="action-btn-small accent-medium">
-                                <p><i class="fa fa-cloud-download fa-5x"></i></p>
-                                <h3>Get Started</h3>
-                            </a>
-                        </div>
-                        <div class="rTableCell">
-                            <a href="http://kiwitcms.readthedocs.io" class="action-btn-small accent-medium">
-                                <p><i class="fa fa-book fa-5x"></i></p>
-                                <h3>Documentation</h3>
-                            </a>
-                        </div>
-                        <div class="rTableCell">
-                            <a href="https://github.com/kiwitcms/Kiwi" class="action-btn-small accent-medium">
-                                <p><i class="fa fa-users fa-5x"></i></p>
-                                <h3>Community</h3>
-                            </a>
-                        </div>
-                        <div class="rTableCell">
-                            <a href="http://mrsenko.com" class="action-btn-small accent-medium">
-                                <p><i class="fa fa-headphones fa-5x"></i></p>
-                                <h3>Support</h3>
-                            </a>
-                        </div>
-                    </div>
+            <div class="secondary">
+                <div class="col-3">
+                    <div class="about-panel-title">Everyday testing</div>
+                    <div class="about-panel-details">Use the dashboard to see pending work. Execute tests, mark results and report bugs. Collect automation results!</div>
                 </div>
+                <div class="col-3">    
+                    <div class="about-panel-title">Test management</div>
+                    <div class="about-panel-details">Define test plans and cases, track progress and assign work across multiple teams. Perform peer reviews.</div>
+                </div>
+                <div class="col-3">
+                    <div class="about-panel-title">Reporting</div>
+                    <div class="about-panel-details">See who's doing what and provide status report to stakeholders. Centralize your acceptance books!</div>
+                </div>
+                <div class="col-3">
+                    <div class="about-panel-title">Integration</div>
+                    <div class="about-panel-details">Integrated with Bugzilla, JIRA and GitHub. The API interface provides full access so you can get creative!</div>
+                </div>
+                <div class="col-3">
+                    <div class="about-panel-title">Django &amp; Python 3</div>
+                    <div class="about-panel-details">We're running the latest Django 1.11.x version on Python 3.5!</div>
+                </div>
+                <div class="col-3">
+                    <div class="about-panel-title">Patternfly &amp; jQuery</div>
+                    <div class="about-panel-details">The UI is created using Patternfly and uses a bit of jQuery!</div>
+                </div>
+                <div class="col-3">
+                    <div class="about-panel-title">Docker</div>
+                    <div class="about-panel-details">Based on a CentOS 7 Docker image and easy to start with docker compose.</div>
+                </div>
+                <div class="col-3">
+                    <div class="about-panel-title">Tested</div>
+                    <div class="about-panel-details">We've got Django and Selenium based tests running in Travis CI!</div>
+                </div>
+            </div>
+            <!-- Call to action btns -->
+            <div class="col-3">
+                <a href="http://kiwitcms.readthedocs.io/en/latest/installing_docker.html" class="action-btn-small accent-medium">
+                    <p><i class="fa fa-cloud-download fa-5x"></i></p>
+                    <h3>Get Started</h3>
+                </a>
+            </div>
+            <div class="col-3">
+                <a href="http://kiwitcms.readthedocs.io" class="action-btn-small accent-medium">
+                    <p><i class="fa fa-book fa-5x"></i></p>
+                    <h3>Documentation</h3>
+                </a>
+            </div>
+            <div class="col-3">
+                <a href="https://github.com/kiwitcms/Kiwi" class="action-btn-small accent-medium">
+                    <p><i class="fa fa-users fa-5x"></i></p>
+                    <h3>Community</h3>
+                </a>
+            </div>
+            <div class="col-3">
+                <a href="http://mrsenko.com" class="action-btn-small accent-medium">
+                    <p><i class="fa fa-headphones fa-5x"></i></p>
+                    <h3>Support</h3>
+                </a>
             </div>
         </section>
         <!-- Screenshots Section -->

--- a/style/style.css
+++ b/style/style.css
@@ -1,4 +1,5 @@
 /*Font sizing*/
+
 h1 {
     font-size: 3.5rem;
 }
@@ -50,6 +51,7 @@ a{
 }
 
 /* Navigation Section */
+
 nav{
     padding: 1rem 0;
     box-shadow: 0 0.2rem 0.5rem 0 rgba(0,0,0, .3);
@@ -153,41 +155,16 @@ ul.topnav li [name="q"] {
     margin-bottom: 5rem;
 }
 
-.about-table{
-    table-layout: fixed;
-    width: 98%;
-    border-spacing: 8rem 0px;
-}
-
-.about-info-panel {
-    text-align: left;
-}
-
-
-/* table into div */
-.rTable {
-    display: block;
-    width: 100%;
-}
-.rTableHeading, .rTableBody, .rTableFoot, .rTableRow{
-    clear: both;
-}
-.rTableHead, .rTableFoot{
+.about-panel-title {
     font-weight: bold;
+    padding-bottom: 0.3rem;
+    padding-left: 1.8rem;  
 }
-.rTableCell, .rTableHead {
-    float: left;
-    overflow: hidden;
-    padding: 0.3rem/*3px*/ 1.8%;
-    width: 21%;
-}
-.rTable:after {
-    visibility: hidden;
-    display: block;
-    font-size: 0;
-    content: " ";
-    clear: both;
-    height: 0;
+
+.about-panel-details {
+    padding-top: 0.3rem;
+    padding-bottom: 1.8rem;
+    padding-left: 1.8rem;      
 }
 
 /* Screenshots Section */


### PR DESCRIPTION
* Group titles and descriptions in the same divs in the about section so that they are grouped logically and so that they could be made responsive easier afterwards.

* Replace the cell-like styling with the col-1 to col-12 separation we made earlier.